### PR TITLE
HTTP ステータスコードとレスポンスヘッダを指定可能に

### DIFF
--- a/src/IisExpressTestKit/IisExpressRequestOptions.cs
+++ b/src/IisExpressTestKit/IisExpressRequestOptions.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Specialized;
+using System.Net;
+
+namespace IisExpressTestKit
+{
+    public class IisExpressRequestOptions
+    {
+        internal IisExpressRequestOptions()
+        {
+            StatusCode = HttpStatusCode.OK;
+            Headers = new NameValueCollection();
+        }
+
+        public HttpStatusCode StatusCode { get; set; }
+
+        public NameValueCollection Headers { get; set; }
+    }
+}

--- a/src/IisExpressTestKit/IisExpressTestKit.csproj
+++ b/src/IisExpressTestKit/IisExpressTestKit.csproj
@@ -68,6 +68,7 @@
     <Compile Include="IisExpress.cs" />
     <Compile Include="IisExpressFixture.cs" />
     <Compile Include="IisExpressResponse.cs" />
+    <Compile Include="IisExpressRequestOptions.cs" />
     <Compile Include="IisRewriteTestBase.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/test/IisExpressTestKit.Tests/RewriteRuleTest.cs
+++ b/test/IisExpressTestKit.Tests/RewriteRuleTest.cs
@@ -53,6 +53,27 @@ namespace IisExpressTestKit.Tests
         }
 
         [Fact]
+        public void StatusCodeのテスト2()
+        {
+            Iis.Request("/statuscode", options: options => options.StatusCode = HttpStatusCode.BadRequest)
+               .IsStatusCode(HttpStatusCode.BadRequest);
+
+            Iis.Request("/statuscode", options: options => options.StatusCode = HttpStatusCode.InternalServerError)
+               .IsStatusCode(HttpStatusCode.InternalServerError);
+        }
+
+        [Fact]
+        public void CustomHeaderのテスト()
+        {
+            Iis.Request("/customheader", options: options =>
+            {
+                options.Headers["Content-Type"] = "application/json";
+            })
+               .IsHeaderValue("Content-Type", "application/json")
+               .IsStatusCode(HttpStatusCode.OK);
+        }
+
+        [Fact]
         public void StaticFileのテスト()
         {
             Iis.Request("/test", "outbound.html")
@@ -75,11 +96,19 @@ namespace IisExpressTestKit.Tests
             Iis.Request("/outboundtest", @".\outbound.html")
                .Contains("<script type='text/javascript'>TRACKING CODE</script>")
                .IsStatusCode(HttpStatusCode.OK);
+
+            Iis.Request("/outboundtest", @".\outbound.txt", options => options.Headers["Content-Type"] = "text/html")
+               .Contains("<script type='text/javascript'>TRACKING CODE</script>")
+               .IsStatusCode(HttpStatusCode.OK);
         }
 
         [Fact]
         public void OutboundRuleのテスト3()
         {
+            Iis.Request("/outboundtest", @".\outbound.html", options => options.Headers["Content-Type"] = "text/plain")
+               .DoesNotContain("<script type='text/javascript'>TRACKING CODE</script>")
+               .IsStatusCode(HttpStatusCode.OK);
+
             Iis.Request("/outboundtest", @".\outbound.txt")
                .DoesNotContain("<script type='text/javascript'>TRACKING CODE</script>")
                .IsStatusCode(HttpStatusCode.OK);

--- a/test/IisExpressTestKit.Tests/Transform.config
+++ b/test/IisExpressTestKit.Tests/Transform.config
@@ -3,12 +3,12 @@
   <system.webServer>
     <rewrite xdt:Transform="Insert">
       <rules configSource="..\..\Rewrite.config" />
-      <outboundRules>
+      <outboundRules> 
         <rule name="Rewrite" preCondition="IsHTML">
           <match filterByTags="A" pattern="^/(hoge.*)" />
           <action type="Rewrite" value="/translated/{R:1}" />
         </rule>
-        <rule name="Add tracking script" patternSyntax="ExactMatch" preCondition="">
+        <rule name="Add tracking script" patternSyntax="ExactMatch" preCondition="IsHTML">
           <match filterByTags="None" pattern="&lt;/body>" />
           <action type="Rewrite" value="&lt;script type='text/javascript'>TRACKING CODE&lt;/script>&lt;/body>" />
         </rule>

--- a/test/IisExpressTestKit.Tests/outbound.txt
+++ b/test/IisExpressTestKit.Tests/outbound.txt
@@ -1,1 +1,11 @@
-﻿outbound test
+﻿<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8" />
+    <title></title>
+</head>
+<body>
+    <a class="test" href="/hoge" rel="me">hoge</a>
+</body>
+</html>


### PR DESCRIPTION
IisExpress.Request にオプションを追加し、ステータスコードとヘッダーの値を指定可能に。
